### PR TITLE
Non square

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,15 +26,16 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-vector": "^2.0.0",
-    "purescript-arrays": "^4.2.0",
-    "purescript-proxy": "^2.1.0"
+    "purescript-vector": "Charles-Schleich/purescript-vector#94ae6dee32ba3fde1ef6c0b6ada8d466f81da4a4",
+    "purescript-arrays": "^5.0.0",
+    "purescript-proxy": "^3.0.0",
+    "purescript-effect": "2.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "^3.0.0",
-    "purescript-console": "^3.0.0",
-    "purescript-random": "^3.0.0",
+    "purescript-assert": "^4.0.0",
+    "purescript-console": "^4.1.0",
+    "purescript-random": "^4.0.0",
     "purescript-spec": "git://github.com/owickstrom/purescript-spec.git#master",
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/src/Data/ST/Matrix.purs
+++ b/src/Data/ST/Matrix.purs
@@ -15,7 +15,10 @@
 module Data.ST.Matrix where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+-- import Effect
+
+-- import Control.Monad.Eff (Eff)
+import Effect
 import Control.Monad.ST (ST())
 import Data.TypeNat (class Sized)
 import Data.Array.ST (STArray)
@@ -26,14 +29,14 @@ newtype STMat r c h a = STMat (STArray h a)
 
 -- try array cloning with .slice() instead of the for-loop
 -- implementation in Data.Array.ST. Needs benchmarking.
-foreign import copyImpl :: forall a b h e. a -> Eff (st :: ST h | e) b
+foreign import copyImpl :: forall a b. a -> Effect b
 
 -- | Create an immutable copy of a mutable array.
-freeze :: forall a h e. STArray h a -> Eff (st :: ST h | e) (Array a)
+freeze :: forall a h e. STArray h a -> Effect (Array a)
 freeze = copyImpl
 
 -- | Create a mutable copy of an immutable array.
-thaw :: forall a h e. Array a -> Eff (st :: ST h | e) (STArray h a)
+thaw :: forall a h e. Array a -> Effect(STArray h a)
 thaw = copyImpl
 
 -- | Freeze an ST array. Do not mutate the STArray afterwards!
@@ -41,32 +44,35 @@ foreign import unsafeFreeze :: forall a h. STArray h a -> Array a
 
 foreign import unsafeThaw :: forall a h. Array a -> STArray h a
 
-cloneSTMat :: forall r c h a e. (STMat r c h a) -> Eff (st :: ST h | e) (STMat r c h a)
+cloneSTMat :: forall r c a. (STMat r c h a) -> Effect(STMat r c h a)
 cloneSTMat (STMat arr) = STMat <<< unsafeThaw <$> freeze arr
 
-fromSTMat :: forall r c h a e. Sized r => Sized c => (STMat r c h a) -> Eff (st :: ST h | e) (M.Mat r c a)
+fromSTMat :: forall r c a. Sized r => Sized c => (STMat r c h a) -> Effect (M.Mat r c a)
 fromSTMat (STMat arr) = do
     x   <- freeze arr
     pure (M.fromArrayColumns x)
 
-toSTMat :: forall r c h a e. (M.Mat r c a) -> Eff (st :: ST h | e) (STMat r c h a)
+toSTMat :: forall r c a. (M.Mat r c a) -> Effect (STMat r c h a)
 toSTMat m = STMat <$> thaw (M.toArrayColumns m)
 
 -- copyToSTMat :: forall r c h a e. (M.Matrix (M.Mat r c) a) => (M.Mat r c a) -> (STMat r c h a) -> Eff (st :: ST h | e) Unit
 
-foreign import copyToSTMat :: forall r c h a e. (M.Mat r c a) -> (STMat r c h a) -> Eff (st :: ST h | e) Unit
+foreign import copyToSTMat :: forall r c h a. (M.Mat r c a) -> (STMat r c h a) -> Effect Unit
 
-identityST' :: forall r c h e. Sized r => Sized c => Eff (st :: ST h | e) (STMat r c h Number)
+identityST' :: forall r c. Sized r => Sized c => Effect (STMat r c h Number)
 identityST' =
     let m = M.identity' :: M.Mat r c Number
     in STMat <$> thaw (M.toArrayColumns m)
 
-foreign import scaleSTMatrixInt :: forall a h e. (EuclideanRing a) => a -> STArray h a -> Eff (st :: ST h | e) Unit
+foreign import scaleSTMatrixInt :: forall h a. (EuclideanRing a) => a -> STArray h a -> Effect Unit
 
-scaleSTMatrix :: forall r c a h e. (EuclideanRing a) => a -> (STMat r c h a) -> Eff (st :: ST h | e) (STMat r c h a)
+scaleSTMatrix :: forall r c a. (EuclideanRing a) => a -> (STMat r c h a) -> Effect (STMat r c h a)
 scaleSTMatrix x v@(STMat arr) = scaleSTMatrixInt x arr *> pure v
 
-fromMatrix :: forall r c a h e. M.Mat r c a -> Eff (st :: ST h | e) (STMat r c h a)
+fromMatrix :: forall r c a. M.Mat r c a -> Effect (STMat r c h a)
 fromMatrix (M.Mat m) = STMat <$> thaw m
 
-foreign import runSTMatrix :: forall r c a e. (forall h. Eff (st :: ST h | e) (STMat r c h a)) -> Eff e (M.Mat r c a)
+foreign import runSTMatrix :: forall s a r. (forall h c. Effect (STMat r c h a)) -> Effect (M.Mat s a) 
+??? not sure above
+
+-- foreign import runSTMatrix :: forall s a r. (forall h. Eff (st :: ST h | r) (STMat s h a)) -> Eff r (M.Mat s a)

--- a/src/Data/ST/Matrix.purs
+++ b/src/Data/ST/Matrix.purs
@@ -15,15 +15,10 @@
 module Data.ST.Matrix where
 
 import Prelude
--- import Effect
-
--- import Control.Monad.Eff (Eff)
-import Effect
-import Control.Monad.ST (ST())
+import Effect (Effect)
 import Data.TypeNat (class Sized)
 import Data.Array.ST (STArray)
 import Data.Matrix as M
-
 
 newtype STMat r c h a = STMat (STArray h a)
 
@@ -32,11 +27,11 @@ newtype STMat r c h a = STMat (STArray h a)
 foreign import copyImpl :: forall a b. a -> Effect b
 
 -- | Create an immutable copy of a mutable array.
-freeze :: forall a h e. STArray h a -> Effect (Array a)
+freeze :: forall a h. STArray h a -> Effect (Array a)
 freeze = copyImpl
 
 -- | Create a mutable copy of an immutable array.
-thaw :: forall a h e. Array a -> Effect(STArray h a)
+thaw :: forall a h. Array a -> Effect(STArray h a)
 thaw = copyImpl
 
 -- | Freeze an ST array. Do not mutate the STArray afterwards!
@@ -44,35 +39,32 @@ foreign import unsafeFreeze :: forall a h. STArray h a -> Array a
 
 foreign import unsafeThaw :: forall a h. Array a -> STArray h a
 
-cloneSTMat :: forall r c a. (STMat r c h a) -> Effect(STMat r c h a)
+cloneSTMat :: forall r c h a. (STMat r c h a) -> Effect (STMat r c h a)
 cloneSTMat (STMat arr) = STMat <<< unsafeThaw <$> freeze arr
 
-fromSTMat :: forall r c a. Sized r => Sized c => (STMat r c h a) -> Effect (M.Mat r c a)
+fromSTMat :: forall r c h a. Sized r => Sized c => (STMat r c h a) -> Effect (M.Mat r c a)
 fromSTMat (STMat arr) = do
     x   <- freeze arr
     pure (M.fromArrayColumns x)
 
-toSTMat :: forall r c a. (M.Mat r c a) -> Effect (STMat r c h a)
+toSTMat :: forall r h c a. (M.Mat r c a) -> Effect (STMat r c h a)
 toSTMat m = STMat <$> thaw (M.toArrayColumns m)
 
 -- copyToSTMat :: forall r c h a e. (M.Matrix (M.Mat r c) a) => (M.Mat r c a) -> (STMat r c h a) -> Eff (st :: ST h | e) Unit
 
 foreign import copyToSTMat :: forall r c h a. (M.Mat r c a) -> (STMat r c h a) -> Effect Unit
 
-identityST' :: forall r c. Sized r => Sized c => Effect (STMat r c h Number)
+identityST' :: forall r c h. Sized r => Sized c => Effect (STMat r c h Number)
 identityST' =
     let m = M.identity' :: M.Mat r c Number
     in STMat <$> thaw (M.toArrayColumns m)
 
 foreign import scaleSTMatrixInt :: forall h a. (EuclideanRing a) => a -> STArray h a -> Effect Unit
 
-scaleSTMatrix :: forall r c a. (EuclideanRing a) => a -> (STMat r c h a) -> Effect (STMat r c h a)
+scaleSTMatrix :: forall r c h a. (EuclideanRing a) => a -> (STMat r c h a) -> Effect (STMat r c h a)
 scaleSTMatrix x v@(STMat arr) = scaleSTMatrixInt x arr *> pure v
 
-fromMatrix :: forall r c a. M.Mat r c a -> Effect (STMat r c h a)
+fromMatrix :: forall r c h a. M.Mat r c a -> Effect (STMat r c h a)
 fromMatrix (M.Mat m) = STMat <$> thaw m
 
-foreign import runSTMatrix :: forall s a r. (forall h c. Effect (STMat r c h a)) -> Effect (M.Mat s a) 
-??? not sure above
-
--- foreign import runSTMatrix :: forall s a r. (forall h. Eff (st :: ST h | r) (STMat s h a)) -> Eff r (M.Mat s a)
+foreign import runSTMatrix :: forall r c a. (forall h. Effect (STMat r c h a)) -> Effect (M.Mat r c a)

--- a/src/Data/ST/Matrix4.purs
+++ b/src/Data/ST/Matrix4.purs
@@ -18,9 +18,8 @@ import Prelude (Unit)
 import Data.TypeNat (Four)
 import Data.Matrix4 (Vec3N())
 import Data.ST.Matrix (STMat)
--- import Control.Monad.Eff (Eff)
 import Effect
-import Control.Monad.ST (ST())
+
 
 type STMat4 h = STMat Four Four h Number
 

--- a/src/Data/ST/Matrix4.purs
+++ b/src/Data/ST/Matrix4.purs
@@ -18,25 +18,26 @@ import Prelude (Unit)
 import Data.TypeNat (Four)
 import Data.Matrix4 (Vec3N())
 import Data.ST.Matrix (STMat)
-import Control.Monad.Eff (Eff)
+-- import Control.Monad.Eff (Eff)
+import Effect
 import Control.Monad.ST (ST())
 
 type STMat4 h = STMat Four Four h Number
 
-foreign import identityST  :: forall h r. Eff (st :: ST h | r) (STMat Four Four h Number)
+foreign import identityST  :: forall h. Effect (STMat Four Four h Number)
 
-foreign import rotateST  :: forall h r. Number -> Vec3N -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import rotateST  :: forall h. Number -> Vec3N -> STMat4 h -> Effect Unit
 
-foreign import rotateSTX  :: forall h r. Number -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import rotateSTX  :: forall h. Number -> STMat4 h -> Effect Unit
 
-foreign import rotateSTY  :: forall h r. Number -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import rotateSTY  :: forall h. Number -> STMat4 h -> Effect Unit
 
-foreign import rotateSTZ  :: forall h r. Number -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import rotateSTZ  :: forall h. Number -> STMat4 h -> Effect Unit
 
 -- generic type was :: forall h r. Number -> [Number] -> STArray h Number -> Eff (st :: ST h | r) Unit
 
-foreign import translateST  :: forall h r. Vec3N -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import translateST  :: forall h. Vec3N -> STMat4 h -> Effect Unit
 
 -- generic type was :: forall h r. [Number] -> STArray h Number -> Eff (st :: ST h | r) Unit
 
-foreign import scaleST3  :: forall h r. Number -> Number -> Number -> STMat4 h -> Eff (st :: ST h | r) Unit
+foreign import scaleST3  :: forall h. Number -> Number -> Number -> STMat4 h -> Effect Unit


### PR DESCRIPTION
Updated for purs 0.12, 
but it depends on a purescript-vector to be updated for 0.12 as well.
I've added a dependency in bower.json to link to purescript-vector i've forked and updated for 0.12.
I'll update the bower.json deps once the purescript-vector v0.12 has been accepted. 
I made some of the same changes to purescript-vector regarding removing dependency on purescript-extensions.
Let me know if there's anything I've missed.